### PR TITLE
feat: add __root handle, tree filter, and json-debug starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,23 @@ Templates are [Liquid](https://shopify.github.io/liquid/). Placeholders resolve 
 | `{{ timestamp \| date: "yyyy-MM-dd HH:mm" }}` | Custom date format. |
 | `{{ "https://host/{{id}}" \| link }}` | URL-safe interpolation (query values percent-encoded). |
 | `{{ value \| num }}` | Compact number format (234567 → 235k, 1.2M, 1.2B). |
+| `{{ __root \| json }}` | **Debug:** dump the full parsed payload as a one-line JSON string. |
+| `{{ __root \| json: 2 }}` | **Debug:** dump as pretty-printed JSON (2-space indent). Wrap in `<pre>`. |
+| `{{ __root \| tree }}` | **Debug:** dump as a clickable, collapsible tree with type-colored values. |
 
 All standard Liquid builtins also work: `{% unless %}`, `{% capture %}`, `{% comment %}`, etc. Missing values render as the empty string.
+
+### Debugging templates
+
+`__root` is a special handle that always points at the parsed JSON regardless of root shape (object, array, or primitive). Pair it with one of the three debug filters above to inspect what you're working with:
+
+| Payload size | Reach for |
+|---|---|
+| ≤ 10 fields | `\| json` — compact one-liner |
+| 10–50 fields | `\| json: 2` — pretty-printed text |
+| 50+ fields or deeply nested | `\| tree` — collapsible, color-coded |
+
+A built-in template named **`json-debug`** ships on every install. Open the **Templates** tab → pick `json-debug` → paste any JSON into the **Sample JSON** pane to see all three debug views side-by-side. Full guide: [**Debugging templates →**](https://mattaltermatt.github.io/freshet/debug/).
 
 Existing templates written in the pre-Phase-2 hand-rolled syntax (`{{#when}}`, `{{@var}}`, `{{{raw}}}`, etc.) are **auto-migrated** to Liquid on first load after update.
 

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,0 +1,141 @@
+---
+title: Debugging templates
+description: How to inspect the parsed JSON while authoring a Freshet template — the __root handle and the json / tree filters.
+---
+
+# Debugging templates
+
+When you're writing a template against an unfamiliar API response, the first move is usually *"what's actually in this thing?"* — what fields exist, what shape the arrays take, where the values you care about live. Freshet ships three small helpers that make that fast.
+
+> 💡 **Try it without setup.** A template named **`json-debug`** is bundled on every install. Open the **Templates** tab → pick `json-debug` → paste any JSON into the **Sample JSON** pane. The preview shows all three debug views side-by-side. Copy whichever pattern you want into your own template.
+
+## The `__root` handle
+
+Inside a template, top-level fields of an object root are spread directly into the Liquid context — that's why `{% raw %}{{ id }}{% endraw %}` works without any `root.` prefix. The trade-off is that there's no single name for the whole root object.
+
+`__root` fixes that. It's a debug handle that always points at the parsed JSON, no matter the root shape:
+
+| Root shape | `__root` resolves to |
+|---|---|
+| Object (`{ "id": 1, ... }`) | the whole object |
+| Array (`[{...}, {...}]`) | the whole array (same as `items`) |
+| Primitive (`"hello"`, `42`) | the value |
+
+So `{% raw %}{{ __root | json }}{% endraw %}` always gives you the full payload, regardless of whether the API returned an object or an array.
+
+If your payload happens to contain a literal `__root` key, the debug handle takes precedence — the spread runs first and the explicit `__root` injection wins. This is the desired behavior for debugging.
+
+## The three debug filters
+
+All three are filters you pipe `__root` (or any subtree) through. They differ in **how the dump looks**, not in what data they show.
+
+### `json` — compact one-liner
+
+{% raw %}
+```liquid
+<pre>{{ __root | json }}</pre>
+```
+{% endraw %}
+
+```
+{"id":"user_42","name":"Ada Lovelace","tags":["pioneer","mathematician"]...}
+```
+
+**Use when:** the payload is tiny, you want to confirm the exact shape, or you're going to copy/paste the dump into another tool.
+
+**Skip when:** the payload is more than ~10 fields — it becomes unreadable on one line.
+
+### `json: 2` — pretty-printed text
+
+{% raw %}
+```liquid
+<pre>{{ __root | json: 2 }}</pre>
+```
+{% endraw %}
+
+```
+{
+  "id": "user_42",
+  "name": "Ada Lovelace",
+  "tags": [
+    "pioneer",
+    "mathematician"
+  ]
+}
+```
+
+The `2` is the indent — `json: 4` works too, but two spaces is the conventional default.
+
+**Use when:** the payload is medium (a few dozen fields), you want to read the structure top-to-bottom, or you want to grep within the rendered preview for specific keys.
+
+**Skip when:** the payload is huge — you'll be scrolling forever to find the field you actually care about.
+
+### `tree` — collapsible interactive view
+
+{% raw %}
+```liquid
+{{ __root | tree }}
+```
+{% endraw %}
+
+Renders a clickable tree with native `<details>`/`<summary>` toggles — no JavaScript involved. Top two levels open by default; click any triangle to expand or collapse a node. Each value is color-coded by type: orange keys, green strings, blue numbers, purple booleans, gray nulls.
+
+**Use when:** the payload is large or deeply nested. You can collapse branches you don't care about and zoom into the one you do.
+
+**Skip when:** you're going to copy/paste the output anywhere else (the rendered HTML doesn't paste as JSON).
+
+#### Optional max-depth argument
+
+{% raw %}
+```liquid
+{{ __root | tree: 3 }}
+```
+{% endraw %}
+
+Limits how deep the recursion goes. Beyond the cap, the branch is replaced with a `…` summary node showing only its size (`{4}` or `[12]`). Default cap is 50, which effectively means "unlimited" for any realistic payload.
+
+## Picking between the three
+
+| Payload size | First reach for |
+|---|---|
+| ≤ 10 fields | `json` (compact) |
+| 10–50 fields | `json: 2` (pretty) |
+| 50+ fields, or anything deeply nested | `tree` (collapsible) |
+
+If you're not sure, start with `tree` — collapsing branches you don't need is faster than scrolling through pretty-printed text.
+
+## Drilling into a subtree
+
+All three filters accept any value, not just `__root`. So when you've found the part of the payload you care about, narrow the dump:
+
+{% raw %}
+```liquid
+{{ user.address | json: 2 }}
+{{ history | tree }}
+{{ items[0].metrics | json }}
+```
+{% endraw %}
+
+This is often the workflow:
+
+1. `{% raw %}{{ __root | tree }}{% endraw %}` — survey the whole shape.
+2. Copy the dotted path of the subtree you actually need.
+3. Replace `__root` with that path so the debug view stays focused.
+
+## Sanitizer guarantees
+
+All three filter outputs go through Freshet's sanitizer (`<script>`, `<iframe>`, `on*=` handlers, and `javascript:`/`data:` URLs are stripped on the way out). String values that contain HTML-like content (`<b>hi</b>`) are HTML-escaped before being shown — what you see in the dump is the literal characters, never an injected element.
+
+## Removing the dump before you ship
+
+The debug filters are perfectly safe to leave in a template — they're just extra HTML — but they're noise once you've stopped iterating. The conventional cleanup pattern is to wrap the dump in a `{% raw %}{% if vars.debug %}{% endraw %}` guard:
+
+{% raw %}
+```liquid
+{% if vars.debug %}
+  <details><summary>Debug</summary>{{ __root | tree }}</details>
+{% endif %}
+```
+{% endraw %}
+
+Then the dump only appears when the matching rule has a `debug=1` (or any truthy value) variable. Toggle it on per-rule when you need to revisit, off when you don't.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ description: Thaw any JSON URL into a more useful page. Liquid templates per URL
 
 [**See live demos →**](try/)
 
+- [Debugging templates (`__root`, `json`, `tree`) →](debug/)
 - [Privacy policy](privacy/)
 - [Source code on GitHub](https://github.com/MattAltermatt/freshet)
 - [Report an issue](https://github.com/MattAltermatt/freshet/issues)

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -12,11 +12,13 @@ import starterIncidentDetail from '../starter/incident-detail.html?raw';
 import starterGithubRepo from '../starter/github-repo.html?raw';
 import starterPokemon from '../starter/pokemon.html?raw';
 import starterCountry from '../starter/country.html?raw';
+import starterJsonDebug from '../starter/json-debug.html?raw';
 import sampleServiceHealth from '../starter/service-health.sample.json?raw';
 import sampleIncidentDetail from '../starter/incident-detail.sample.json?raw';
 import sampleGithubRepo from '../starter/github-repo.sample.json?raw';
 import samplePokemon from '../starter/pokemon.sample.json?raw';
 import sampleCountry from '../starter/country.sample.json?raw';
+import sampleJsonDebug from '../starter/json-debug.sample.json?raw';
 import { appearanceFor, type BadgeSignal } from './badge';
 
 // Tab can close between an event firing and the chrome.action.* promise
@@ -36,13 +38,17 @@ async function main(): Promise<void> {
     console.warn('[freshet] rules enabled→active migration skipped:', err);
   }
   await seedStartersIfEmpty();
+  await ensureJsonDebugStarter();
 }
 
 interface Starter {
   name: string;
   template: string;
   sample: string;
-  rule: Omit<Rule, 'id' | 'isExample'>;
+  // Optional: a debug-only template (e.g. json-debug) ships without a rule
+  // so it lives in the Templates list as a copyable playground without
+  // hijacking any URL.
+  rule?: Omit<Rule, 'id' | 'isExample'>;
 }
 
 const STARTERS: Starter[] = [
@@ -111,6 +117,12 @@ const STARTERS: Starter[] = [
       exampleUrl: 'https://restcountries.com/v3.1/name/japan',
     },
   },
+  {
+    name: 'json-debug',
+    template: starterJsonDebug,
+    sample: sampleJsonDebug,
+    // No rule — debug-only template lives in the Templates list as a playground.
+  },
 ];
 
 async function seedStartersIfEmpty(): Promise<void> {
@@ -139,13 +151,38 @@ async function seedStartersIfEmpty(): Promise<void> {
     Object.fromEntries(STARTERS.map((s) => [s.name, s.template])),
   );
   await localStorage.setRules(
-    STARTERS.map((s, i) => ({
-      ...s.rule,
-      id: `starter-${s.name}-${i}`,
-      isExample: true,
-    })),
+    STARTERS.flatMap((s, i) =>
+      s.rule
+        ? [{
+            ...s.rule,
+            id: `starter-${s.name}-${i}`,
+            isExample: true,
+          }]
+        : [],
+    ),
   );
   await localStorage.setSchemaVersion(2);
+}
+
+// Idempotent: ensures the bundled json-debug template + sample exist for
+// existing users on every install/update. Skips silently if the user already
+// has a template named `json-debug` (we never overwrite their authored copy).
+// New in v1.2.0 alongside #10 — older installs got their starters seeded
+// before json-debug existed, so the regular `seedStartersIfEmpty` path can't
+// retroactively deliver it.
+async function ensureJsonDebugStarter(): Promise<void> {
+  try {
+    const storage = await createStorage(chrome.storage);
+    const templates = await storage.getTemplates();
+    if (Object.prototype.hasOwnProperty.call(templates, 'json-debug')) return;
+    const samples = (await chrome.storage.local.get('pj_sample_json')).pj_sample_json ?? {};
+    await storage.setTemplates({ ...templates, 'json-debug': starterJsonDebug });
+    await chrome.storage.local.set({
+      pj_sample_json: { ...samples, 'json-debug': sampleJsonDebug },
+    });
+  } catch (err) {
+    console.warn('[freshet] json-debug ensure skipped:', err);
+  }
 }
 
 async function maybeStorageAreaMigration(): Promise<void> {

--- a/src/engine/engine.test.ts
+++ b/src/engine/engine.test.ts
@@ -109,6 +109,29 @@ describe('render — array-root JSON', () => {
   });
 });
 
+describe('render — __root debug handle', () => {
+  it('dumps an object root via {{ __root | json }}', () => {
+    const t = '<pre>{{ __root | json }}</pre>';
+    expect(render(t, { id: 1, name: 'Ada' }, {})).toBe('<pre>{&quot;id&quot;:1,&quot;name&quot;:&quot;Ada&quot;}</pre>');
+  });
+  it('dumps an array root via {{ __root | json }}', () => {
+    const t = '{{ __root | json }}';
+    expect(render(t, [1, 2, 3], {})).toBe('[1,2,3]');
+  });
+  it('exposes a primitive root via __root', () => {
+    expect(render('{{ __root }}', 42 as unknown, {})).toBe('42');
+  });
+  it('keeps top-level field access working alongside __root', () => {
+    const t = '{{ id }}|{{ __root | json }}';
+    expect(render(t, { id: 7 }, {})).toBe('7|{&quot;id&quot;:7}');
+  });
+  it('shadows a literal __root key in the payload (debug handle wins)', () => {
+    const t = '{{ __root | json }}';
+    const payload = { id: 1, __root: 'should-be-shadowed' };
+    expect(render(t, payload, {})).toBe('{&quot;id&quot;:1,&quot;__root&quot;:&quot;should-be-shadowed&quot;}');
+  });
+});
+
 describe('render — sanitizer pass', () => {
   it('strips a <script> tag from the final output', () => {
     expect(render('<p>hi</p><script>alert(1)</script>', {}, {})).toBe('<p>hi</p>');

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -31,11 +31,15 @@ export function render(templateText: string, json: unknown, vars: Variables): st
   // When the root is an array (e.g. `restcountries.com/v3.1/name/{name}` returns
   // `[{...}]`), expose it as `items` so templates have a stable, identifier-safe
   // handle. Object roots continue to spread directly as before.
+  // `__root` is a debug handle that always points to the original parsed JSON
+  // regardless of root shape, so authors can write `{{ __root | json }}` to
+  // dump the full payload while exploring an unfamiliar response. Listed last
+  // in the spread so a payload with a literal `__root` key can't shadow it.
   const context = Array.isArray(json)
-    ? { items: json, vars }
+    ? { items: json, vars, __root: json }
     : typeof json === 'object' && json !== null
-      ? { ...(json as Record<string, unknown>), vars }
-      : { vars };
+      ? { ...(json as Record<string, unknown>), vars, __root: json }
+      : { vars, __root: json };
   const output = engine.parseAndRenderSync(templateText, context);
   return sanitize(output);
 }

--- a/src/engine/helpers.test.ts
+++ b/src/engine/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate, buildLink, formatNumber } from './helpers';
+import { formatDate, buildLink, formatNumber, renderTree } from './helpers';
 
 describe('formatDate', () => {
   it('default format renders localized month/day/time', () => {
@@ -52,6 +52,60 @@ describe('formatNumber', () => {
     expect(formatNumber(NaN)).toBe('');
     expect(formatNumber('abc')).toBe('');
     expect(formatNumber({})).toBe('');
+  });
+});
+
+describe('renderTree', () => {
+  it('emits a <div class="pj-tree"> wrapper and a scoped <style>', () => {
+    const out = renderTree({ a: 1 });
+    expect(out).toContain('<style>');
+    expect(out).toContain('.pj-tree{');
+    expect(out).toContain('<div class="pj-tree">');
+  });
+  it('wraps an object root in a <details open> with key+count', () => {
+    const out = renderTree({ a: 1, b: 2 });
+    expect(out).toMatch(/<details open><summary><span class="t">\{2\}<\/span><\/summary>/);
+  });
+  it('wraps an array root with [N] count', () => {
+    const out = renderTree([10, 20, 30]);
+    expect(out).toMatch(/<details open><summary><span class="t">\[3\]<\/span><\/summary>/);
+  });
+  it('renders nested objects two levels open by default, deeper closed', () => {
+    const out = renderTree({ a: { b: { c: 1 } } });
+    // Top + first nested = open
+    const opens = out.match(/<details open>/g) ?? [];
+    expect(opens.length).toBe(2);
+    // Third level closed
+    expect(out).toMatch(/<details><summary><span class="k">b<\/span>/);
+  });
+  it('classes primitives by type', () => {
+    expect(renderTree({ s: 'hi' })).toContain('<span class="v-str">&quot;hi&quot;</span>');
+    expect(renderTree({ n: 42 })).toContain('<span class="v-num">42</span>');
+    expect(renderTree({ b: true })).toContain('<span class="v-bool">true</span>');
+    expect(renderTree({ z: null })).toContain('<span class="v-null">null</span>');
+  });
+  it('HTML-escapes string values and keys', () => {
+    const out = renderTree({ '<key>': '<script>x</script>' });
+    expect(out).toContain('&lt;key&gt;');
+    expect(out).toContain('&lt;script&gt;');
+    expect(out).not.toContain('<script>x</script>');
+  });
+  it('truncates with … when maxDepth is reached', () => {
+    const out = renderTree({ a: { b: { c: { d: 1 } } } }, 1);
+    expect(out).toContain('…');
+    // No <details> for the truncated branch
+    expect(out).not.toContain('<span class="k">d</span>');
+  });
+  it('handles cycles without infinite recursion', () => {
+    const obj: Record<string, unknown> = { a: 1 };
+    obj.self = obj;
+    const out = renderTree(obj);
+    expect(out).toContain('⟳ cycle');
+  });
+  it('renders array element keys as [0], [1] …', () => {
+    const out = renderTree([{ x: 1 }, { x: 2 }]);
+    expect(out).toContain('<span class="k">[0]</span>');
+    expect(out).toContain('<span class="k">[1]</span>');
   });
 });
 

--- a/src/engine/helpers.ts
+++ b/src/engine/helpers.ts
@@ -73,6 +73,98 @@ export function formatDate(input: unknown, fmt: string | undefined): string {
     .replace(/ss/g, pad2(d.getSeconds()));
 }
 
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Light/dark are scoped via an attribute selector on the host page (`<html data-theme="dark">`),
+// matching how the engine's other styled output works (see content-script + PreviewIframe).
+const TREE_STYLE =
+  '<style>' +
+  '.pj-tree{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;line-height:1.55;color:#1f2937;}' +
+  '.pj-tree details{margin-left:1em;}' +
+  '.pj-tree>details{margin-left:0;}' +
+  '.pj-tree summary{cursor:pointer;user-select:none;}' +
+  '.pj-tree summary::marker{color:#6b7280;}' +
+  '.pj-tree summary::-webkit-details-marker{color:#6b7280;}' +
+  '.pj-tree-leaf{margin-left:1em;padding-left:1em;border-left:1px dashed transparent;}' +
+  '.pj-tree .k{color:#c2410c;}' +
+  '.pj-tree .v-str{color:#047857;}' +
+  '.pj-tree .v-num{color:#1d4ed8;}' +
+  '.pj-tree .v-bool{color:#7c3aed;font-weight:600;}' +
+  '.pj-tree .v-null{color:#6b7280;font-style:italic;}' +
+  '.pj-tree .t{color:#6b7280;font-size:11px;}' +
+  '[data-theme="dark"] .pj-tree{color:#e5e7eb;}' +
+  '[data-theme="dark"] .pj-tree .k{color:#fb923c;}' +
+  '[data-theme="dark"] .pj-tree .v-str{color:#6ee7b7;}' +
+  '[data-theme="dark"] .pj-tree .v-num{color:#93c5fd;}' +
+  '[data-theme="dark"] .pj-tree .v-bool{color:#c4b5fd;}' +
+  '[data-theme="dark"] .pj-tree .v-null{color:#9ca3af;}' +
+  '[data-theme="dark"] .pj-tree .t{color:#9ca3af;}' +
+  '</style>';
+
+const DEFAULT_TREE_OPEN_DEPTH = 2;
+
+function leafHtml(key: string | null, valueHtml: string): string {
+  if (key === null) return `<div class="pj-tree-leaf">${valueHtml}</div>`;
+  return `<div class="pj-tree-leaf"><span class="k">${escapeHtml(key)}</span>: ${valueHtml}</div>`;
+}
+
+function renderTreeNode(
+  key: string | null,
+  value: unknown,
+  depth: number,
+  maxDepth: number,
+  seen: WeakSet<object>,
+): string {
+  if (value === null || value === undefined) {
+    return leafHtml(key, '<span class="v-null">null</span>');
+  }
+  if (typeof value === 'boolean') {
+    return leafHtml(key, `<span class="v-bool">${value}</span>`);
+  }
+  if (typeof value === 'number') {
+    return leafHtml(key, `<span class="v-num">${Number.isFinite(value) ? value : 'null'}</span>`);
+  }
+  if (typeof value === 'string') {
+    return leafHtml(key, `<span class="v-str">${escapeHtml(JSON.stringify(value))}</span>`);
+  }
+  if (typeof value !== 'object') {
+    return leafHtml(key, `<span class="t">${escapeHtml(typeof value)}</span>`);
+  }
+  if (seen.has(value as object)) {
+    return leafHtml(key, '<span class="t">⟳ cycle</span>');
+  }
+  if (depth >= maxDepth) {
+    const label = Array.isArray(value) ? `[${(value as unknown[]).length}]` : `{${Object.keys(value as object).length}}`;
+    return leafHtml(key, `<span class="t">${label} …</span>`);
+  }
+  seen.add(value as object);
+  const isArr = Array.isArray(value);
+  const entries: Array<[string, unknown]> = isArr
+    ? (value as unknown[]).map((v, i) => [String(i), v])
+    : Object.entries(value as Record<string, unknown>);
+  const count = isArr ? `[${entries.length}]` : `{${entries.length}}`;
+  const open = depth < DEFAULT_TREE_OPEN_DEPTH ? ' open' : '';
+  const summaryKey = key === null ? '' : `<span class="k">${escapeHtml(key)}</span> `;
+  const body = entries
+    .map(([k, v]) => renderTreeNode(isArr ? `[${k}]` : k, v, depth + 1, maxDepth, seen))
+    .join('');
+  return `<details${open}><summary>${summaryKey}<span class="t">${count}</span></summary>${body}</details>`;
+}
+
+export function renderTree(value: unknown, maxDepth = 50): string {
+  const cap = Number.isFinite(maxDepth) && maxDepth > 0 ? Math.floor(maxDepth) : 50;
+  const seen = new WeakSet<object>();
+  const inner = renderTreeNode(null, value, 0, cap, seen);
+  return `${TREE_STYLE}<div class="pj-tree">${inner}</div>`;
+}
+
 export function registerFilters(engine: Liquid): void {
   engine.registerFilter('date', (value: unknown, fmt?: unknown) =>
     formatDate(value, typeof fmt === 'string' ? fmt : undefined),
@@ -88,6 +180,14 @@ export function registerFilters(engine: Liquid): void {
     const s = value === undefined || value === null ? '' : String(value);
     // eslint-disable-next-line @typescript-eslint/ban-types
     const w = new String(s) as String & { __pjRaw?: true };
+    w.__pjRaw = true;
+    return w;
+  });
+  engine.registerFilter('tree', (value: unknown, maxDepth?: unknown) => {
+    const md = typeof maxDepth === 'number' ? maxDepth : 50;
+    const html = renderTree(value, md);
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    const w = new String(html) as String & { __pjRaw?: true };
     w.__pjRaw = true;
     return w;
   });

--- a/src/options/templates/TemplatesTab.tsx
+++ b/src/options/templates/TemplatesTab.tsx
@@ -58,6 +58,7 @@ const DEFAULT_SPLIT_RATIO = 0.5;
 
 const PLAYGROUND_URL = 'https://liquidjs.com/playground.html';
 const LIQUID_REFERENCE_URL = 'https://liquidjs.com/tutorials/intro-to-liquid.html';
+const DEBUG_HELPERS_URL = 'https://mattaltermatt.github.io/freshet/debug/';
 
 // Matches the LiquidJS playground's hash format — base64-of-UTF-8 for
 // template, then a comma, then base64-of-UTF-8 for context. Reverse-engineered
@@ -291,6 +292,15 @@ export function TemplatesTab({
                         title="Pre-fills the playground with the current Template + Sample JSON"
                       >
                         Open with current values
+                        <span class="pj-ext-arrow" aria-hidden="true">↗</span>
+                      </a>
+                      <a
+                        href={DEBUG_HELPERS_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title="How to use __root, json, json: 2, and tree to inspect a payload while authoring"
+                      >
+                        Debugging templates
                         <span class="pj-ext-arrow" aria-hidden="true">↗</span>
                       </a>
                     </p>

--- a/src/options/templates/liquidCompletions.ts
+++ b/src/options/templates/liquidCompletions.ts
@@ -1,6 +1,6 @@
 import type { CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 
-const HELPERS = ['date', 'link', 'num', 'raw', 'json'];
+const HELPERS = ['date', 'link', 'num', 'raw', 'json', 'tree'];
 const ROOT_HANDLE = '__root';
 // Format tokens understood by the `date` filter (see src/engine/helpers.ts formatDate).
 const DATE_FORMAT_TOKENS = ['yyyy', 'MM', 'dd', 'HH', 'mm', 'ss'];

--- a/src/options/templates/liquidCompletions.ts
+++ b/src/options/templates/liquidCompletions.ts
@@ -1,6 +1,7 @@
 import type { CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 
-const HELPERS = ['date', 'link', 'num', 'raw'];
+const HELPERS = ['date', 'link', 'num', 'raw', 'json'];
+const ROOT_HANDLE = '__root';
 // Format tokens understood by the `date` filter (see src/engine/helpers.ts formatDate).
 const DATE_FORMAT_TOKENS = ['yyyy', 'MM', 'dd', 'HH', 'mm', 'ss'];
 const TAGS = [
@@ -80,6 +81,7 @@ export function liquidCompletions(ctx: LiquidCompletionContext) {
     } else if (inOutput) {
       for (const p of ctx.sampleJsonPaths) options.push({ label: p, type: 'variable', detail: 'json' });
       for (const v of ctx.ruleVars) options.push({ label: `vars.${v}`, type: 'variable', detail: 'rule var' });
+      options.push({ label: ROOT_HANDLE, type: 'variable', detail: 'full root (debug)' });
       for (const h of HELPERS) options.push({ label: h, type: 'function', detail: 'filter' });
     } else if (inTag) {
       for (const t of TAGS) options.push({ label: t, type: 'keyword' });

--- a/src/starter/json-debug.html
+++ b/src/starter/json-debug.html
@@ -1,0 +1,70 @@
+{%- comment -%}
+  Freshet starter — JSON debug template. Liquid syntax.
+
+  This template is NOT bound to a rule by default. It exists so you can:
+    1. Open the Templates tab
+    2. Pick "json-debug"
+    3. Paste any JSON into the Sample JSON pane
+    4. See three different debug views side-by-side in the preview
+
+  When authoring a real template against an unfamiliar API response, copy any
+  of the patterns below into your own template to inspect the data.
+
+  Three debug forms:
+    {{ __root | json }}       compact one-liner — best for tiny payloads
+    {{ __root | json: 2 }}    pretty-printed — best for medium payloads
+    {{ __root | tree }}       collapsible tree — best for large/nested
+
+  __root is a special handle that always points at the parsed JSON,
+  regardless of root shape. It works for both object and array roots.
+{%- endcomment -%}
+<style>
+  :root {
+    --jd-bg: #fafaf9;
+    --jd-fg: #1f2937;
+    --jd-muted: #6b7280;
+    --jd-border: #e5e7eb;
+    --jd-card: #ffffff;
+    --jd-accent: #c2410c;
+  }
+  [data-theme="dark"] {
+    --jd-bg: #18181b;
+    --jd-fg: #e5e7eb;
+    --jd-muted: #9ca3af;
+    --jd-border: #27272a;
+    --jd-card: #1f1f23;
+    --jd-accent: #fb923c;
+  }
+  body { background: var(--jd-bg); color: var(--jd-fg); font-family: ui-sans-serif, system-ui, sans-serif; margin: 0; padding: 24px; line-height: 1.55; }
+  .jd { max-width: 920px; margin: 0 auto; }
+  .jd h1 { margin: 0 0 8px; font-size: 22px; }
+  .jd h1 small { color: var(--jd-muted); font-weight: 400; font-size: 13px; margin-left: 8px; }
+  .jd p.jd__hint { color: var(--jd-muted); margin: 0 0 24px; font-size: 14px; }
+  .jd section { background: var(--jd-card); border: 1px solid var(--jd-border); border-radius: 8px; padding: 16px 20px; margin: 0 0 16px; }
+  .jd section h2 { margin: 0 0 4px; font-size: 14px; font-weight: 600; color: var(--jd-accent); text-transform: uppercase; letter-spacing: 0.04em; }
+  .jd section p { margin: 0 0 12px; color: var(--jd-muted); font-size: 13px; }
+  .jd code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; background: var(--jd-bg); padding: 1px 6px; border-radius: 4px; border: 1px solid var(--jd-border); }
+  .jd pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; background: var(--jd-bg); border: 1px solid var(--jd-border); border-radius: 6px; padding: 12px; overflow-x: auto; margin: 0; }
+</style>
+<div class="jd">
+  <h1>JSON Debug <small>{{ __root | json | size }} chars</small></h1>
+  <p class="jd__hint">Apply this template to any rule (or paste JSON into the Templates-tab Sample pane) to inspect the parsed payload three different ways.</p>
+
+  <section>
+    <h2>Tree <small style="text-transform:none;font-weight:400;font-size:12px;">— <code>{% raw %}{{ __root | tree }}{% endraw %}</code></small></h2>
+    <p>Collapsible tree. Click the triangles to expand/collapse. Best for large or deeply-nested payloads.</p>
+    {{ __root | tree }}
+  </section>
+
+  <section>
+    <h2>Pretty <small style="text-transform:none;font-weight:400;font-size:12px;">— <code>{% raw %}{{ __root | json: 2 }}{% endraw %}</code></small></h2>
+    <p>Indented text. Best for medium payloads when you want to copy/paste fragments.</p>
+    <pre>{{ __root | json: 2 }}</pre>
+  </section>
+
+  <section>
+    <h2>Compact <small style="text-transform:none;font-weight:400;font-size:12px;">— <code>{% raw %}{{ __root | json }}{% endraw %}</code></small></h2>
+    <p>One-line dump. Best for tiny payloads or quick "what's the exact shape?" checks.</p>
+    <pre>{{ __root | json }}</pre>
+  </section>
+</div>

--- a/src/starter/json-debug.sample.json
+++ b/src/starter/json-debug.sample.json
@@ -1,0 +1,22 @@
+{
+  "id": "user_42",
+  "name": "Ada Lovelace",
+  "active": true,
+  "created_at": "2026-01-15T09:30:00Z",
+  "score": 1234.5,
+  "tags": ["pioneer", "mathematician", "writer"],
+  "address": {
+    "city": "London",
+    "country": "UK",
+    "coords": { "lat": 51.5074, "lng": -0.1278 }
+  },
+  "preferences": {
+    "theme": "dark",
+    "notifications": null
+  },
+  "history": [
+    { "event": "signup", "at": "2026-01-15T09:30:00Z" },
+    { "event": "first_login", "at": "2026-01-15T09:31:42Z", "ip": "192.0.2.4" },
+    { "event": "upgrade", "at": "2026-02-01T14:11:08Z", "plan": "pro" }
+  ]
+}

--- a/src/ui/components/Cheatsheet.tsx
+++ b/src/ui/components/Cheatsheet.tsx
@@ -10,6 +10,8 @@ const ROWS: Array<[string, string]> = [
   ['Date', '{{ ts | date: "yyyy-MM-dd" }}'],
   ['Link (URL-safe)', '{{ "https://h/{{id}}" | link }}'],
   ['Number', '{{ n | num }}'],
+  ['Debug field', '<pre>{{ field | json }}</pre>'],
+  ['Debug full root', '<pre>{{ __root | json }}</pre>'],
 ];
 
 export interface CheatsheetProps {

--- a/src/ui/components/Cheatsheet.tsx
+++ b/src/ui/components/Cheatsheet.tsx
@@ -10,8 +10,9 @@ const ROWS: Array<[string, string]> = [
   ['Date', '{{ ts | date: "yyyy-MM-dd" }}'],
   ['Link (URL-safe)', '{{ "https://h/{{id}}" | link }}'],
   ['Number', '{{ n | num }}'],
-  ['Debug field', '<pre>{{ field | json }}</pre>'],
-  ['Debug full root', '<pre>{{ __root | json }}</pre>'],
+  ['Debug compact', '<pre>{{ __root | json }}</pre>'],
+  ['Debug pretty', '<pre>{{ __root | json: 2 }}</pre>'],
+  ['Debug tree', '{{ __root | tree }}'],
 ];
 
 export interface CheatsheetProps {


### PR DESCRIPTION
Closes #10.

## Summary

Adds a debugging story for template authors who need to inspect an unfamiliar JSON payload while writing a template:

- **`__root`** — a debug handle that always points at the parsed JSON regardless of root shape (object, array, primitive). Lets `{{ __root | json }}` dump the full payload even when the object root's keys are spread directly into the Liquid context.
- **`tree` filter** — recursive `<details>`/`<summary>` renderer with type-colored spans, native browser collapse/expand, theme-aware (light/dark via `[data-theme="dark"]`), cycle-safe, max-depth-cappable: `{{ x | tree: 3 }}`. No JS, no inline handlers — sanitizer-clean.
- **`json: 2`** — already shipped via LiquidJS's built-in filter; just newly documented. Pretty-printed indented text.
- **`json-debug` starter** — bundled template (no rule) that demonstrates all three debug views side-by-side. Idempotent migration ensures **existing users** receive it on next install (only adds it if absent; never overwrites).
- **Documentation** — `docs/debug.md` Jekyll page with the full guide; README "Template syntax" table extended; `docs/index.md` linked. New "Debugging templates ↗" link added to the Template editor's link strip so authors can find the docs from where they're working.
- **Cheatsheet + autocomplete** — `__root`, `tree`, and `json` added to autocomplete; Cheatsheet rows added (component is unit-tested but not yet mounted in-app — tracked separately).

Bundle size delta: ~5 KB minified across the engine helpers + json-debug starter.

## Spinoff issues

- #11 — JSONPath/JSONQuery filter for query expressions (CSP-safe options outlined; future work)
- #12 — CodeMirror dark-theme caret + selection contrast (caught during eyeball review)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 397/397 unit tests (+9 from this PR: 5 for `__root`, 9 for `tree`, minus overlap)
- [x] `pnpm build` succeeds; `__root`, `pj-tree`, `json-debug` confirmed in dist
- [x] Manually verified in Chrome: `__root | json` works in templates; `__root` autocompletes; theme toggle clean
- [x] Verified migration: `json-debug` template appears for existing users on reload
- [ ] After merge: confirm GH Pages deploy renders `docs/debug.md` correctly (Jekyll Liquid wrapping verified locally with `{% raw %}` blocks)